### PR TITLE
Handle posted lists.

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,4 +32,5 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test
       run: |
-        python -m unittest
+        pip install django
+        DJANGO_SETTINGS_MODULE=django_settings python -m unittest

--- a/django_settings.py
+++ b/django_settings.py
@@ -1,0 +1,1 @@
+SECRET_KEY = "something"

--- a/lite_forms/submitters.py
+++ b/lite_forms/submitters.py
@@ -24,7 +24,14 @@ def submit_single_form(request: HttpRequest, form: Form, post_to, pk=None, overr
     return None, validated_data
 
 
-def submit_paged_form(request: HttpRequest, form_group: FormGroup, post_to, pk=None, inject_data=None):
+def submit_paged_form(
+    request: HttpRequest,
+    form_group: FormGroup,
+    post_to,
+    pk=None,
+    inject_data=None,
+    expect_many_values=[],
+):
     data = request.POST.copy()
 
     if inject_data:
@@ -38,8 +45,13 @@ def submit_paged_form(request: HttpRequest, form_group: FormGroup, post_to, pk=N
     del data['form_pk']
     del data['csrfmiddlewaretoken']
 
+    # Ensure data which is expected to have multiple values.
+    for many_value_key in expect_many_values:
+        data[many_value_key] = request.POST.getlist(many_value_key)
+
     # Post the data to the validator and check for errors
     nested_data = nest_data(data)
+
     if pk:
         validated_data, status_code = post_to(request, pk, nested_data)
     else:
@@ -73,7 +85,11 @@ def submit_paged_form(request: HttpRequest, form_group: FormGroup, post_to, pk=N
 
     # Add existing post data to new form as hidden fields
     for key, value in data.items():
-        next_form.questions.insert(0, HiddenField(key, value))
+        if key in expect_many_values:
+            for sub_value in value:
+                next_form.questions.insert(0, HiddenField(key, sub_value))
+        else:
+            next_form.questions.insert(0, HiddenField(key, value))
 
     # Go to the next page
     return form_page(request, next_form, data=data), validated_data

--- a/lite_forms/submitters.py
+++ b/lite_forms/submitters.py
@@ -30,8 +30,11 @@ def submit_paged_form(
     post_to,
     pk=None,
     inject_data=None,
-    expect_many_values=[],
+    expect_many_values=None,
 ):
+    if expect_many_values is None:
+        expect_many_values = []
+
     data = request.POST.copy()
 
     if inject_data:


### PR DESCRIPTION
Adds support for `expect_many_values` parameter to `submit_paged_form`.

This allows us to handle multiple values as a list, rather than having to serialise multiple values as JSON, a comma delimited list, or some other mechanism.

Lists of values should be posted as multiple fields:

```html
<input type="hidden" name="pizza_topping" value="cheese">
<input type="hidden" name="pizza_topping" value="tomato">
<input type="hidden" name="pizza_topping" value="olive">
```

If `submit_paged_form` is called with `expect_many_values=["pizza_topping"]`, a list of pizza toppings will be used (instead of just `olive`, which would be a pretty dull pizza).