### PR TITLE
chore: Changes to pass internal frontend linting.

### DIFF
--- a/templatetags/custom_tags.py
+++ b/templatetags/custom_tags.py
@@ -46,4 +46,9 @@ def key_in_array(data, key):
 
 @register.filter
 def prefix_dots(text):
-    return text.replace('.', '\\\.')
+    """
+    Prefix dots in an ID so it can be used in a jQuery selector.
+
+    See https://stackoverflow.com/a/9930611
+    """
+    return text.replace('.', r'\\.')

--- a/tests.py
+++ b/tests.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from lite_forms.components import Form, DetailComponent, TextInput, FormGroup
 from lite_forms.helpers import nest_data, flatten_data, remove_unused_errors, get_form_by_pk
 from lite_forms.submitters import submit_paged_form
+from lite_forms.templatetags.custom_tags import prefix_dots
 
 
 class FormTests(TestCase):
@@ -135,3 +136,12 @@ class TestSubmitPagedFormTestCase(TestCase):
             "key_d": "h",
             "key_e": [],
         })
+
+
+class TemplateTagsTestCase(TestCase):
+    def test_prefix_dots(self):
+        self.assertEqual("nodots", prefix_dots("nodots"))
+        self.assertEqual(r"\\.startdot", prefix_dots(".startdot"))
+        self.assertEqual(r"enddot\\.", prefix_dots("enddot."))
+        self.assertEqual(r"mid\\.dot", prefix_dots("mid.dot"))
+        self.assertEqual(r"\\.all\\.the\\.dots\\.", prefix_dots(".all.the.dots."))


### PR DESCRIPTION
`submit_paged_form` was judged to be too complex, so I've split it into two functions.

The slashes in `prefix_dots` were seen as invalid escape sequences. I've:
* changed this function;
* added a comment explaining what it does; and
* added a test to ensure I haven't broken it.