### PR TITLE
feat: Links in labels

### DIFF
--- a/components.py
+++ b/components.py
@@ -82,8 +82,13 @@ class FormGroup:
 
 
 class Label:
-    def __init__(self, text: str):
-        self.text = text
+    def __init__(self, text: str, create_links=True):
+        if create_links:
+            from lite_forms.helpers import extract_links
+            self.text = extract_links(text)
+        else:
+            self.text = text
+        self.create_links = create_links
         self.input_type = "label"
 
 

--- a/components.py
+++ b/components.py
@@ -425,3 +425,13 @@ class ControlListEntryInput:
         self.optional = optional
         self.classes = classes
         self.input_type = "control_list_entry"
+
+
+class Link:
+    def __init__(self, text, address, classes: [] = None):
+        self.text = text
+        self.address = address
+        self.classes = classes
+
+    def __eq__(self, other):
+        return other.text == self.text and other.address == self.address

--- a/helpers.py
+++ b/helpers.py
@@ -1,4 +1,5 @@
 import copy
+import re
 
 from collections.abc import MutableMapping
 

--- a/helpers.py
+++ b/helpers.py
@@ -2,7 +2,7 @@ import copy
 
 from collections.abc import MutableMapping
 
-from lite_forms.components import FormGroup
+from lite_forms.components import FormGroup, Link
 
 
 def get_form_by_pk(form_pk, form_group: FormGroup):
@@ -111,3 +111,25 @@ def conditional(condition: bool, obj, else_obj=None):
         return obj
 
     return else_obj
+
+
+def extract_links(text: str):
+    """
+    Takes a string and splits into a list of strings and links
+    based on markdown conventions
+    """
+    markup_regex = '(.*?)(\[.*?\))([^\[]*)'
+    link_regex = "\[(.*)\]\((.*)\)"
+
+    return_value = []
+
+    for match in re.findall(markup_regex, text):
+        for item in [x for x in match if x]:
+            value = re.findall(link_regex, item)
+
+            if len(value) == 0:
+                return_value.append(item)
+            else:
+                return_value.append(Link(value[0][0], value[0][1]))
+
+    return [x for x in return_value if x]

--- a/templates/components.html
+++ b/templates/components.html
@@ -74,7 +74,7 @@
 		{% elif question.input_type == "list" %}
 			{% include "components/list.html" with component=question %}
 		{% elif question.input_type == "label" %}
-			{% include "components/label.html" with text=question.text %}
+			{% include "components/label.html" with component=question %}
         {% elif question.input_type == "control_list_entry" %}
 			{% include "components/control_list_entry.html" with component=question value=data|key_value:question.name|default:'' error=errors|key_value:question.name %}
         {% elif question.input_type == "markdown" %}

--- a/templates/components/label.html
+++ b/templates/components/label.html
@@ -1,1 +1,7 @@
-<p class="govuk-body">{{ text }}</p>
+{% if component.create_links %}
+	<p class="govuk-body">
+		{% for item in component.text %}{% if item|classname == "Link" %}<a class="govuk-link" href="{{ item.address }}">{{ item.text }}</a>{% else %}<span>{{ item }}</span>{% endif %}{% endfor %}
+	</p>
+{% else %}
+	<p class="govuk-body">{{ component.text }}</p>
+{% endif %}


### PR DESCRIPTION
This update adds markdown links to labels, so you can write `[I Am Easy to Find](https://www.americanmary.com)` to create a link.

Preview of component:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/43062514/70132718-a77d8b80-167c-11ea-898f-d19cadc7404a.png">
